### PR TITLE
fix invalid sign when passing url_* params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,7 +141,7 @@ class Cryptomus {
      */
     makeSignatue(data, key) {
         const signatue = (0, crypto_1.createHash)('md5')
-            .update(Buffer.from(JSON.stringify(data).replace(/\//g, '\\/')).toString('base64') + key)
+            .update(Buffer.from(JSON.stringify(data)).toString('base64') + key)
             .digest('hex');
         return signatue;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export class Cryptomus {
         const signatue = createHash( 'md5' )
             .update(
                 Buffer.from(
-                    JSON.stringify( data ).replace( /\//g, '\\/' ),
+                    JSON.stringify( data ),
                 ).toString( 'base64' ) + key,
             )
             .digest( 'hex' );


### PR DESCRIPTION
This PR fixes the issue described in [this GitHub issue](https://github.com/qweme32/cryptomus/issues/1).

The URLs passed in the `url_*` parameters were being altered by regex. For example:

`https://example.com/success` was being changed to `https:\/\/example.com\/success`, causing the signature and payload to not match and rendering the signature invalid.